### PR TITLE
Add users age, parent email, and timestamps

### DIFF
--- a/api/email/emailRouter.js
+++ b/api/email/emailRouter.js
@@ -49,7 +49,8 @@ router.post('/register', async (req, res) => {
         sendUrl = `https://ss-mvp.herokuapp.com/email/activate/?token=${validationHash}&email=${email}`;
     }
 
-
+    // send email to parent instead of user, if given.
+    // ToDo: change this to a separate ToS/PP confirmation email
     sendEmail(parentEmail || email, sendUrl);
 
     return res.status(200).json({ message: 'User created, waiting for validation.' })    

--- a/api/email/emailRouter.js
+++ b/api/email/emailRouter.js
@@ -19,7 +19,7 @@ router.post('/register', async (req, res) => {
         return res.status(400).json({ error: 'Username and Password are required.' });
     } 
     
-    const { email, password, username } = req.body;
+    const { email, password, username, age, parentEmail } = req.body;
 
     const existingUser = await auth.getUserId(email);
     if (existingUser) {
@@ -32,8 +32,10 @@ router.post('/register', async (req, res) => {
     const newUser = {
         email,
         username,
-        password: bc.hashSync(password, 10),       
-        validationUrl: validationHash
+        password: bc.hashSync(password, 10),
+        age,
+        parentEmail,
+        validationUrl: validationHash,
     }
     await auth.addUser(newUser);
     
@@ -45,11 +47,10 @@ router.post('/register', async (req, res) => {
 
     }else {
         sendUrl = `https://ss-mvp.herokuapp.com/email/activate/?token=${validationHash}&email=${email}`;
-
     }
 
 
-    sendEmail(email, sendUrl);
+    sendEmail(parentEmail || email, sendUrl);
 
     return res.status(200).json({ message: 'User created, waiting for validation.' })    
 })

--- a/data/migrations/20200813155748_age.js
+++ b/data/migrations/20200813155748_age.js
@@ -1,0 +1,17 @@
+const { table } = require("../dbConfig");
+
+exports.up = function(knex) {
+  return knex.schema.alterTable('users', table => {
+    table.integer('age').notNullable().defaultTo(13)
+    table.string('parentEmail', 128)
+    table.timestamps(false, true)
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('users', table => {
+      table.dropTimestamps()
+      table.dropColumn('parentEmail')
+      table.dropColumn('age')
+  })
+};


### PR DESCRIPTION
Trello Card:  https://trello.com/c/EArBxMuR/50-age

Front End PR: https://github.com/ss-mvp/story-master-fe/pull/24

### Description

As a user, I want to be able to select my age when registering for an account.

As a developer, I want to be able to save a user's age in the database.

### Back End

- [x] Add Age to user model
- [x] Add Parents Email to user model
- [x] Email validation to Parents' Email if given
- [x] Add new migration

### Known Issues:

This implementation simply changes the recipient of the validation email to the parent email. Thus the user email is still unverified. Instead we will likely need to create a separate email prompt for "reading and agreeing to the ToS and Privacy Policy", which then pings back end to send the original email verification.