### PR TITLE
Upload alternative

### DIFF
--- a/.platform/nginx/conf.d/proxy.conf
+++ b/.platform/nginx/conf.d/proxy.conf
@@ -1,1 +1,1 @@
-client_max_body_size 50M;
+client_max_body_size 25M;

--- a/api/server.js
+++ b/api/server.js
@@ -1,8 +1,6 @@
 const express = require("express");
 const helmet = require("helmet");
 const cors = require("cors");
-// const multer = require('multer');
-// const newUpload = multer();
 
 const forceHttps = require('@crystallize/elasticloadbalancer-express-force-https');
 

--- a/api/server.js
+++ b/api/server.js
@@ -144,34 +144,6 @@ server.use(cors(
     methods: ['POST', 'GET', 'OPTIONS', 'PUT']
   }
 ));
-// if(process.env.BE_ENV === 'development'){
-//   server.use(cors());
-// }else {
-
-//   // server.use(function(req, res, next) {
-//   //   const origins = ['https://condescending-edison-aa86dd.netlify.app', 'https://goofy-shirley-2a2ca3.netlify.app']
-//   //   const origin = req.headers.origin
-  
-//   //   if (origins.indexOf(origin) > -1) {
-//   //     res.setHeader("Access-Control-Allow-Origin", origin)
-//   //   }
-//   //   // res.header("Access-Control-Allow-Origin", "*");
-//   //   // res.header("Access-Control-Allow-Origin", "https://contest.storysquad.app"); // update to match the domain you will make the request from
-//   //   res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-//   //   res.header("Access-Control-Allow-Headers", 'Origin,X-Requested-With,Content-Type,Accept,content-type,application/json');
-//   //   res.header('Access-Control-Allow-Credentials', true);
-//   //   next();
-//   // });
-//   // server.use(cors());
-//   server.use(function(req, res, next) {
-//     res.header('Access-Control-Allow-Origin', '*')
-//     res.header('Access-Control-Allow-Credentials', true)
-//     res.header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
-//     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization')
-//     next()
-//   })
-
-// }
 
 server.use(bodyParser.urlencoded({ extended: false, limit: "50mb" }));
 server.use(bodyParser.json({ limit: "50mb" }));

--- a/api/server.js
+++ b/api/server.js
@@ -145,8 +145,8 @@ server.use(cors(
   }
 ));
 
-server.use(bodyParser.urlencoded({ extended: false, limit: "50mb" }));
-server.use(bodyParser.json({ limit: "50mb" }));
+server.use(bodyParser.urlencoded({ extended: false, limit: "25mb" }));
+server.use(bodyParser.json({ limit: "25mb" }));
 // server.use(newUpload.array());
 
 server.use("/email", emailRouter);

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -63,7 +63,7 @@ router.post("/", restricted, fileUpload({ limits: { fileSize: 50 * 1024 * 1024 }
       }
       else
       {
-        //Create the databsse insert
+        //Create the database insert
         const sendPackage = {
           image: data.Location,
           pages: transcribed,

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -1,5 +1,5 @@
 const router = require("express").Router();
-const upload = require("../../services/file-upload.js");
+const s3 = require("../../services/file-upload.js");
 const story = require("./storyModel.js");
 const users = require("../email/emailModel.js");
 const admin = require("../admin/adminModel.js")
@@ -31,43 +31,99 @@ const onlyTranscription = (data) => {
 //   }
 // })
 
-router.post("/", restricted, async (req, res) => {
-  const singleUpload = upload.single("image");
-  singleUpload(req, res, async function (e) {
-    const images = [];
-    images.push(req.body.base64Image);
-    console.log(req.body);
-    let transcribed = await transcribe({ images });
-    transcribed = JSON.parse(transcribed);
-    console.log("TRANSCRIBEDDDD",transcribed);
+const fileUpload = require("express-fileupload");
+router.post("/", restricted, fileUpload({ limits: { fileSize: 50 * 1024 * 1024 }}), async (req, res) => {
+  //Convert to Base64
+  let base64 = `data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`;
 
-    let readability = await readable({ story: transcribed.images[0] });
-    readability = JSON.parse(readability);
-    console.log(readability)
+  //Verify the image meets our standards here
 
-    if (e) return res.status(400).json({ error: e.message });
+  ///////////////////////////////////////////
 
-    const sendPackage = {
-      image: req.file.location,
-      pages: transcribed,
-      readability,
-      prompt_id: req.body.promptId,
-      userId: req.userId,
-      flag: transcribed.flagged.flag,
-      flagged: transcribed.flagged.isFlagged,
-      score: readability.ranking_score
-    };
-    console.log('send', sendPackage)
+  //Transcribe and rate the image
+  const images = [];
+  images.push(base64);
+  let transcribed = await transcribe({ images });
+  transcribed = JSON.parse(transcribed);
+  let readability = await readable({ story: transcribed.images[0] });
+  readability = JSON.parse(readability);
 
-    await story
-      .addImage(sendPackage)
-      .then((response) => {
-        console.log(response);
-      })
-      .catch((err) => console.log(err));
+  //Upload to S3 Directly
+  s3.upload(
+    {
+      Bucket: "storysquad",
+      Key: Date.now().toString(),
+      Metadata: { "Test": "Test Metadata" },
+      Body: req.files.image.data
+    }, async function (err, data) {
+      if (err)
+      {
+        console.log(err);
+        return res.status(400).json({ error: err });
+      }
+      else
+      {
+        //Create the databsse insert
+        const sendPackage = {
+          image: data.Location,
+          pages: transcribed,
+          readability,
+          prompt_id: req.body.promptId,
+          userId: req.userId,
+          flag: transcribed.flagged.flag,
+          flagged: transcribed.flagged.isFlagged,
+          score: readability.ranking_score
+        };
 
-    return res.status(201).json({ imageUrl: req.file.location });
-  })
+        //AddImage, this also has a select that's creating an error
+        //But the error isn't for anything useful so idk
+        await story
+          .addImage(sendPackage)
+          .then((response) => {
+            console.log(response);
+          })
+          .catch((err) => console.log(err));
+        
+        //Return the new S3 link url
+        return res.status(201).json({ imageUrl: data.Location });
+      }
+    }
+  )
+
+  // const singleUpload = upload.single("image");
+  // singleUpload(req, res, async function (e) {
+  //   const images = [];
+  //   images.push(`data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`);
+  //   let transcribed = await transcribe({ images });
+  //   transcribed = JSON.parse(transcribed);
+
+  //   let readability = await readable({ story: transcribed.images[0] });
+  //   readability = JSON.parse(readability);
+
+  //   if (e) return res.status(400).json({ error: e.message });
+
+  //   const sendPackage = {
+  //     image: req.file.location,
+  //     pages: transcribed,
+  //     readability,
+  //     prompt_id: req.body.promptId,
+  //     userId: req.userId,
+  //     flag: transcribed.flagged.flag,
+  //     flagged: transcribed.flagged.isFlagged,
+  //     score: readability.ranking_score
+  //   };
+
+  //   console.log(sendPackage);
+
+  //   await story
+  //     .addImage(sendPackage)
+  //     .then((response) => {
+  //       console.log(response);
+  //     })
+  //     .catch((err) => console.log(err));
+
+  //   return res.status(201).json({ imageUrl: req.file.location });
+  // })
 });
 
 router.get('/video', restricted, async (req, res) => {

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -44,7 +44,7 @@ router.post("/", restricted, _FileUploadConf, async (req, res) => {
   let base64 = `data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`;
 
   //Verify the image meets our standards here (More coming!)
-  if (!req.files.image.mimetype.contains("image"))
+  if (!req.files.image.mimetype.includes("image"))
     return res.status(400).json({ error: "Invalid image type" });
   ///////////////////////////////////////////
 

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -32,7 +32,14 @@ const onlyTranscription = (data) => {
 // })
 
 const fileUpload = require("express-fileupload");
-router.post("/", restricted, fileUpload({ limits: { fileSize: 25 * 1024 * 1024 }}), async (req, res) => {
+let _FileUploadConf = fileUpload(
+  {
+    limits: { fileSize: 25 * 1024 * 1024 },
+    abortOnLimit: true,
+    responseOnLimit: "File size too large",
+    uploadTimeout: 40000 //40 Sec
+  });
+router.post("/", restricted, _FileUploadConf, async (req, res) => {
   //Convert to Base64
   let base64 = `data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`;
 

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -61,7 +61,6 @@ router.post("/", restricted, _FileUploadConf, async (req, res) => {
     {
       Bucket: "storysquad",
       Key: Date.now().toString(),
-      Metadata: { "Test": "Test Metadata" },
       Body: req.files.image.data
     }, async function (err, data) {
       if (err)

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -36,8 +36,9 @@ router.post("/", restricted, fileUpload({ limits: { fileSize: 25 * 1024 * 1024 }
   //Convert to Base64
   let base64 = `data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`;
 
-  //Verify the image meets our standards here
-
+  //Verify the image meets our standards here (More coming!)
+  if (!req.files.image.mimetype.contains("image"))
+    return res.status(400).json({ error: "Invalid image type" });
   ///////////////////////////////////////////
 
   //Transcribe and rate the image

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -32,7 +32,7 @@ const onlyTranscription = (data) => {
 // })
 
 const fileUpload = require("express-fileupload");
-router.post("/", restricted, fileUpload({ limits: { fileSize: 50 * 1024 * 1024 }}), async (req, res) => {
+router.post("/", restricted, fileUpload({ limits: { fileSize: 25 * 1024 * 1024 }}), async (req, res) => {
   //Convert to Base64
   let base64 = `data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`;
 

--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -89,41 +89,6 @@ router.post("/", restricted, fileUpload({ limits: { fileSize: 50 * 1024 * 1024 }
       }
     }
   )
-
-  // const singleUpload = upload.single("image");
-  // singleUpload(req, res, async function (e) {
-  //   const images = [];
-  //   images.push(`data:${req.files.image.mimetype};base64,${req.files.image.data.toString('base64')}`);
-  //   let transcribed = await transcribe({ images });
-  //   transcribed = JSON.parse(transcribed);
-
-  //   let readability = await readable({ story: transcribed.images[0] });
-  //   readability = JSON.parse(readability);
-
-  //   if (e) return res.status(400).json({ error: e.message });
-
-  //   const sendPackage = {
-  //     image: req.file.location,
-  //     pages: transcribed,
-  //     readability,
-  //     prompt_id: req.body.promptId,
-  //     userId: req.userId,
-  //     flag: transcribed.flagged.flag,
-  //     flagged: transcribed.flagged.isFlagged,
-  //     score: readability.ranking_score
-  //   };
-
-  //   console.log(sendPackage);
-
-  //   await story
-  //     .addImage(sendPackage)
-  //     .then((response) => {
-  //       console.log(response);
-  //     })
-  //     .catch((err) => console.log(err));
-
-  //   return res.status(201).json({ imageUrl: req.file.location });
-  // })
 });
 
 router.get('/video', restricted, async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "knex": "^0.20.13",
     "knex-cleaner": "^1.3.0",
     "moment": "^2.24.0",
-    "multer": "^1.4.2",
-    "multer-s3": "^2.9.0",
     "nodemailer": "^6.4.6",
     "nodemailer-express-handlebars": "^4.0.0",
     "nodemailer-ses-transport": "^1.5.1",

--- a/services/file-upload.js
+++ b/services/file-upload.js
@@ -1,6 +1,6 @@
 const aws = require('aws-sdk');
-const multer = require('multer');
-const multerS3 = require('multer-s3');
+// const multer = require('multer');
+// const multerS3 = require('multer-s3');
 const dotenv = require('dotenv');
 dotenv.config();
 
@@ -12,18 +12,18 @@ aws.config.update({
 
 const s3 = new aws.S3();
 
-const upload = multer({
-    storage: multerS3({
-        s3: s3,
-        bucket: 'storysquad',
-        acl: 'public-read',
-        metadata: function(req, file, cb) {
-            cb(null, {fieldName: 'Testing Metadata'});
-        },
-        key: function(req, file, cb) {
-            cb(null, Date.now().toString())
-        }
-    })
-})
+// const upload = multer({
+//     storage: multerS3({
+//         s3: s3,
+//         bucket: 'storysquad',
+//         acl: 'public-read',
+//         metadata: function(req, file, cb) {
+//             cb(null, {fieldName: 'Testing Metadata'});
+//         },
+//         key: function(req, file, cb) {
+//             cb(null, Date.now().toString())
+//         }
+//     })
+// })
 
-module.exports = upload;
+module.exports = s3;

--- a/services/file-upload.js
+++ b/services/file-upload.js
@@ -1,6 +1,4 @@
 const aws = require('aws-sdk');
-// const multer = require('multer');
-// const multerS3 = require('multer-s3');
 const dotenv = require('dotenv');
 dotenv.config();
 
@@ -11,19 +9,5 @@ aws.config.update({
 });
 
 const s3 = new aws.S3();
-
-// const upload = multer({
-//     storage: multerS3({
-//         s3: s3,
-//         bucket: 'storysquad',
-//         acl: 'public-read',
-//         metadata: function(req, file, cb) {
-//             cb(null, {fieldName: 'Testing Metadata'});
-//         },
-//         key: function(req, file, cb) {
-//             cb(null, Date.now().toString())
-//         }
-//     })
-// })
 
 module.exports = s3;


### PR DESCRIPTION
Alternative method of uploading to parse the incoming data manually and remove the need to transmit the image in Base64 along with the raw bytes, to just the raw bytes, and translating to Base64 for the Python transcription using the buffer.

Also did a bit of cleaning, and directly incorporated the AWS-SDK S3 bucket into the upload.

* Set upload limit to 25MB rather than 50MB.