### PR TITLE
Removed restricted middleware from the get/upload/image/:id endpoint

### DIFF
--- a/api/story/storyRouter.js
+++ b/api/story/storyRouter.js
@@ -152,7 +152,7 @@ router.post("/", restricted(), _FileUploadConf, async (req, res) => {
   )
 });
 
-router.get("/image/:id", restricted(), async (req, res) =>
+router.get("/image/:id", async (req, res) =>
 {
   let ID = req.params.id;
 


### PR DESCRIPTION
This endpoint needs to be unrestricted so that users can view the submissions when they're voting on them.
