### PR TITLE
Fix wrong e-mail template being delivered

### DIFF
--- a/services/mailer.js
+++ b/services/mailer.js
@@ -11,6 +11,20 @@ const transporter = nm.createTransport(
     )
 );
 
+const handlebarOptions = {
+    viewEngine:
+    {
+        extName: ".handlebars",
+        partialsDir: "./templates/",
+        layoutsDir: "./templates/",
+        defaultLayout: ""
+    },
+    viewPath: "./templates/",
+    extName: ".handlebars"
+};
+
+transporter.use("compile", hbs(handlebarOptions));
+
 function SendMail(
     toAddress, // E-Mail to send to
     subject, //E-Mail subject line
@@ -18,22 +32,8 @@ function SendMail(
     paramaterObject // Object containing paramaters to place inside email
 )
 {
-    const handlebarOptions = {
-        viewEngine:
-        {
-            extName: ".handlebars",
-            partialsDir: "./templates/",
-            layoutsDir: "./templates/",
-            defaultLayout: ""
-        },
-        viewPath: "./templates/",
-        extName: ".handlebars"
-    };
-
-    transporter.use("compile", hbs(handlebarOptions));
-
     let MailOptions = {
-        from: "support@storysquad.app",
+        from: "StorySquad <support@storysquad.app>",
         to: toAddress,
         subject: subject,
         context: paramaterObject,

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -24,12 +24,12 @@ function SendMail(
             extName: ".handlebars",
             partialsDir: "./templates/",
             layoutsDir: "./templates/",
-            defaultLayout: `${templateFile}.handlebars`
+            defaultLayout: ""
         },
         viewPath: "./templates/",
         extName: ".handlebars"
     };
-    
+
     transporter.use("compile", hbs(handlebarOptions));
 
     let MailOptions = {
@@ -54,4 +54,4 @@ function SendMail(
 
 module.exports = {
     SendMail
-}
+};


### PR DESCRIPTION
Node was not clearing the memory for the handlebar configuration object, and was forcing the default template name to "main" - this defaults it to blank, telling the templater to use the name provided.

Bonus points; Adds 'StorySquad' as the email sender now.