### PR TITLE
Feature/block username emails

### DIFF
--- a/api/email/emailModel.js
+++ b/api/email/emailModel.js
@@ -63,7 +63,7 @@ async function isActivated(email)
 
 function getToken(email) 
 {
-    return db("users").where({ email }).select("validationUrl", "validated").first();
+    return db("users").where({ email }).select("validationUrl", "validated", "username", "email", "id").first();
 };
 
 function activateEmail(email, validate) 

--- a/api/email/emailModel.js
+++ b/api/email/emailModel.js
@@ -15,7 +15,8 @@ module.exports = {
     getResetByUID,
     getFullResetRow,
     deleteResetsByUID,
-    saveResetCode
+    saveResetCode,
+    userNamePattern
 };
 
 function getAllUsers() 
@@ -112,5 +113,28 @@ async function saveResetCode(uid, code)
     catch (ex) 
     {
         console.log(ex); return -1;
+    }
+}
+
+// Regex checking if the username only contains letters and numbers
+async function userNamePattern(username) 
+{
+    {
+        const codenamePattern = /^[A-Za-z0-9]*$/;
+        try 
+        {
+            if (codenamePattern.test(username)) 
+            {
+                return true
+            }
+            else 
+            {
+                return false
+            }
+        }
+        catch (error) 
+        {
+            console.log(error)   
+        }
     }
 }

--- a/api/email/emailModel.js
+++ b/api/email/emailModel.js
@@ -16,7 +16,7 @@ module.exports = {
     getFullResetRow,
     deleteResetsByUID,
     saveResetCode,
-    userNamePattern
+    registerUserPatternCheck
 };
 
 function getAllUsers() 
@@ -117,24 +117,24 @@ async function saveResetCode(uid, code)
 }
 
 // Regex checking if the username only contains letters and numbers
-async function userNamePattern(username) 
+// Regex checking if the password includesCapital, includesNumber, checkLength
+function registerUserPatternCheck(username, password) 
 {
+    const codenamePattern = /^[A-Za-z0-9]*$/;
+
+    const includesCapital = /[A-Z]/;
+    const includesNumber = /[0-9]/;
+
+    if (codenamePattern.test(username) && 
+        (password.length >= 8 && password.length <= 32) && 
+        includesCapital.test(password) && 
+        includesNumber.test(password)
+    ) 
     {
-        const codenamePattern = /^[A-Za-z0-9]*$/;
-        try 
-        {
-            if (codenamePattern.test(username)) 
-            {
-                return true
-            }
-            else 
-            {
-                return false
-            }
-        }
-        catch (error) 
-        {
-            console.log(error)   
-        }
+        return true
+    }
+    else 
+    {
+        return false
     }
 }

--- a/api/email/emailRouter.js
+++ b/api/email/emailRouter.js
@@ -26,10 +26,9 @@ router.post("/register", async (req, res) =>
         return res.status(400).json({ error: "Username already in use" });
 
     // Ensure username is not an email to prevent web scrappers and "stalking like" activity for public data
-    // 409 is the correct status code for duplicate resource or resource already exists
-    let codenameCheck = await auth.userNamePattern(req.body.username)
+    let codenameCheck = auth.registerUserPatternCheck(req.body.username, req.body.password)
     if (!codenameCheck)
-        return res.status(409).json({ error: "Only letters and numbers are allowed for codenames." });
+        return res.status(400).json({ error: "Username or Password Invalid." });
 
     let validationToken = uuid.v5(username, uuidNamespace);
 

--- a/api/email/emailRouter.js
+++ b/api/email/emailRouter.js
@@ -214,7 +214,7 @@ function signToken(user)
     };
 
     const options = {
-        expiresIn: "1d"
+        expiresIn: "2d"
     };
 
     return jwt.sign(payload, jwtSecret, options);

--- a/api/email/emailRouter.js
+++ b/api/email/emailRouter.js
@@ -91,16 +91,23 @@ router.get("/activate", async (req, res) =>
     //Return res.status(300).json({ error: 'Token and email are required for validation' });
 
     const data = await auth.getToken(req.query.email);
-
+    
     if (!data || data.validated || (req.query.token !== data.validationUrl))
         return res.redirect("https://contest.storysquad.app/");
-
+    
     await auth.activateEmail(req.query.email, { validated: true });
 
+    const user = {
+        username: data.username,
+        email: data.email,
+        id: data.id
+    }
+    const authToken = signToken(user)
+    
     if (process.env.BE_ENV === "development")
-        res.redirect(`http://localhost:3000/activated?token=${req.query.token}`);
+        res.redirect(`http://localhost:3000/activated?authToken=${authToken}`);
     else
-        res.redirect(`https://contest.storysquad.app/activated?token=${req.query.token}`);
+        res.redirect(`https://contest.storysquad.app/activated?authToken=${authToken}`);
 });
 
 router.get("/reset", async (req, res) =>

--- a/api/email/emailRouter.js
+++ b/api/email/emailRouter.js
@@ -25,6 +25,12 @@ router.post("/register", async (req, res) =>
     if (existingUsername)
         return res.status(400).json({ error: "Username already in use" });
 
+    // Ensure username is not an email to prevent web scrappers and "stalking like" activity for public data
+    // 409 is the correct status code for duplicate resource or resource already exists
+    let codenameCheck = await auth.userNamePattern(req.body.username)
+    if (!codenameCheck)
+        return res.status(409).json({ error: "Only letters and numbers are allowed for codenames." });
+
     let validationToken = uuid.v5(username, uuidNamespace);
 
     let newUser =


### PR DESCRIPTION
# Codenames & Emails 

We do not want Codenames (usernames) to be emails to prevent web scrappers and people from getting our users personal emails.
We want users passwords to follow the front end rules of length, a capital letter and a number as well.

## Auth Token

Send a jwt token to the FE when a user is activated so the user can signed in automatically opposed to manually logging in after activation. 